### PR TITLE
[TT-17030] Fix git auth: use x-access-token prefix for GitHub App tokens

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -26,7 +26,7 @@ jobs:
         with:
           go-version: '1.23.2'
 
-      - run: git config --global url.https://${{ steps.app-token.outputs.token }}@github.com/.insteadOf https://github.com/
+      - run: git config --global url.https://x-access-token:${{ steps.app-token.outputs.token }}@github.com/.insteadOf https://github.com/
       - name: Run GoReleaser
         uses: goreleaser/goreleaser-action@v6
         with:


### PR DESCRIPTION
## Summary
- Add `x-access-token:` prefix to the token in the `insteadOf` URL in release.yml (1 occurrence)
- The bare token format doesn't work when `actions/checkout` has configured a credential helper; the `x-access-token:` prefix fixes this

## Test plan
- [ ] Verify release workflow can pull private Go modules

🤖 Generated with [Claude Code](https://claude.com/claude-code)